### PR TITLE
Update media_player.py

### DIFF
--- a/custom_components/hass_agent/media_player.py
+++ b/custom_components/hass_agent/media_player.py
@@ -283,7 +283,7 @@ class HassAgentMediaPlayerDevice(MediaPlayerEntity):
 
     async def async_play_media(self, media_type: str, media_id: str, **kwargs: Any):
         """Play media source"""
-        if not media_type.startswith("audio/"):
+        if not media_type.startswith("music"):
             _logger.error(
                 "Invalid media type %r. Only %s is supported!",
                 media_type,


### PR DESCRIPTION
#3 
I changed the media_player.py script to check for media type music* instead of audio/*. I have tested and media_player is now able to play mp3's for me with media_content_type = music