### PR TITLE
Add reload service call and fix MQTT is not enabled at startup 

### DIFF
--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -132,7 +132,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if url is not None:
 
         def get_device_info():
-            return requests.get(f"{url}/info", timeout=10)
+            return requests.get(f"{url}/info", timeout=60)
 
         response = await hass.async_add_executor_job(get_device_info)
 

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -233,8 +233,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         ]
 
         await asyncio.gather(*reload_tasks)
-#        await process_config(await async_setup_entry(hass, DOMAIN))
 
-    async_register_admin_service(hass, DOMAIN, SERVICE_RELOAD, reload_config)
+    hass.helpers.service.async_register_admin_service(
+        DOMAIN,
+        SERVICE_RELOAD,
+        _handle_reload,
+    )
 
     return True

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -39,7 +39,7 @@ from .const import DOMAIN
 DOMAIN = "hass_agent"
 FOLDER = "hass_agent"
 
-PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
+PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.MQTT]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -222,6 +222,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up hass_agent integration."""
     hass.http.register_view(MediaPlayerThumbnailView(hass))
 
+    """Set up the MQTT state feed."""
+    # Make sure MQTT is available and the entry is loaded
+#    if not hass.config_entries.async_entries(
+#        mqtt.DOMAIN
+#    ) or not await hass.config_entries.async_wait_component(
+#        hass.config_entries.async_entries(mqtt.DOMAIN)[0]
+#    ):
+#        _LOGGER.error("MQTT integration is not available")
+#        return False
+        
     async def _handle_reload(service):
         """Handle reload service call."""
         _LOGGER.info("Service %s.reload called: reloading integration", DOMAIN)

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -11,9 +11,10 @@ import requests
 from typing import Any, cast
 from .views import MediaPlayerThumbnailView
 
-import voluptuous as vol
+#import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.components import mqtt
 from homeassistant.components.mqtt.models import ReceiveMessage
 from homeassistant.components.mqtt.subscription import (
     async_prepare_subscribe_topics,
@@ -24,6 +25,8 @@ from homeassistant.const import (
     CONF_ID,
     CONF_NAME, 
     CONF_URL, 
+    DATA_MQTT,
+    DATA_MQTT_AVAILABLE,
     Platform, 
     SERVICE_RELOAD,
 )

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -5,6 +5,7 @@ import logging
 import requests
 from .views import MediaPlayerThumbnailView
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.components.mqtt.models import ReceiveMessage
 from homeassistant.components.mqtt.subscription import (
     async_prepare_subscribe_topics,
@@ -24,6 +25,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import discovery
 
 from .const import DOMAIN
+
+DOMAIN = "hass_agent"
+
+FOLDER = "hass_agent"
 
 PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
 
@@ -209,20 +214,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-async def async_setup(hass: HomeAssistant, config) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.http.register_view(MediaPlayerThumbnailView(hass))
-
-    async def _handle_reload(service):
-        """Handle reload service call."""
-        _LOGGER.info("Service %s.reload called: reloading integration", DOMAIN)
-
-        current_entries = hass.config_entries.async_entries(DOMAIN)
-
-        reload_tasks = [
-            hass.config_entries.async_reload(entry.entry_id)
-            for entry in current_entries
-        ]
-
-        await asyncio.gather(*reload_tasks)
+    hass.services.register(DOMAIN, SERVICE_RELOAD)
     
     return True

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -226,7 +226,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Reload configuration."""
         await process_config(await async_integration_yaml_config(hass, DOMAIN))
 
-    await process_config(config)
     async_register_admin_service(hass, DOMAIN, SERVICE_RELOAD, reload_config)
 
     return True

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -41,7 +41,7 @@ FOLDER = "hass_agent"
 
 PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
 
-_logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 def update_device_info(hass: HomeAssistant, entry: ConfigEntry, new_device_info):
     device_registry = dr.async_get(hass)

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -222,9 +222,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up hass_agent integration."""
     hass.http.register_view(MediaPlayerThumbnailView(hass))
 
-    async def reload_config(_: ServiceCall) -> None:
-        """Reload configuration."""
+    async def _handle_reload(service):
+        """Handle reload service call."""
         _LOGGER.info("Service %s.reload called: reloading integration", DOMAIN)
+
         current_entries = hass.config_entries.async_entries(DOMAIN)
 
         reload_tasks = [

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -42,7 +42,7 @@ PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
 
 _LOGGER = logging.getLogger(__name__)
 
-def update_device_info(hass: HomeAssistant, entry: ConfigEntry, new_device_info):
+async def update_device_info(hass: HomeAssistant, entry: ConfigEntry, new_device_info):
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
@@ -181,12 +181,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         sub_state = hass.data[DOMAIN][entry.entry_id]["internal_mqtt"]
 
-        def updated(message: ReceiveMessage):
+        async def updated(message: ReceiveMessage):
             payload = json.loads(message.payload)
             cached = hass.data[DOMAIN][entry.entry_id]["apis"]
             apis = payload["apis"]
 
-            update_device_info(hass, entry, payload)
+            await update_device_info(hass, entry, payload)
 
             if cached != apis:
                 hass.async_create_task(handle_apis_changed(hass, entry, apis))

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -39,7 +39,7 @@ from .const import DOMAIN
 DOMAIN = "hass_agent"
 FOLDER = "hass_agent"
 
-PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
+PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.]
 
 _logger = logging.getLogger(__name__)
 
@@ -222,10 +222,19 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up hass_agent integration."""
     hass.http.register_view(MediaPlayerThumbnailView(hass))
 
-#    async def reload_config(_: ServiceCall) -> None:
+    async def reload_config(_: ServiceCall) -> None:
         """Reload configuration."""
-#        await process_config(await async_integration_yaml_config(hass, DOMAIN))
+         _LOGGER.info("Service %s.reload called: reloading integration", DOMAIN)
+        current_entries = hass.config_entries.async_entries(DOMAIN)
 
-    async_register_admin_service(hass, DOMAIN, SERVICE_RELOAD)
+        reload_tasks = [
+            hass.config_entries.async_reload(entry.entry_id)
+            for entry in current_entries
+        ]
+
+        await asyncio.gather(*reload_tasks)
+#        await process_config(await async_setup_entry(hass, DOMAIN))
+
+    async_register_admin_service(hass, DOMAIN, SERVICE_RELOAD, reload_config)
 
     return True

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -13,7 +13,13 @@ from homeassistant.components.mqtt.subscription import (
 )
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ID, CONF_NAME, CONF_URL, Platform
+from homeassistant.const import (
+    CONF_ID,
+    CONF_NAME, 
+    CONF_URL, 
+    Platform, 
+    SERVICE_RELOAD,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import discovery
 
@@ -205,4 +211,18 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_setup(hass: HomeAssistant, config) -> bool:
     hass.http.register_view(MediaPlayerThumbnailView(hass))
+
+    async def _handle_reload(service):
+        """Handle reload service call."""
+        _LOGGER.info("Service %s.reload called: reloading integration", DOMAIN)
+
+        current_entries = hass.config_entries.async_entries(DOMAIN)
+
+        reload_tasks = [
+            hass.config_entries.async_reload(entry.entry_id)
+            for entry in current_entries
+        ]
+
+        await asyncio.gather(*reload_tasks)
+    
     return True

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -224,7 +224,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def reload_config(_: ServiceCall) -> None:
         """Reload configuration."""
-         _LOGGER.info("Service %s.reload called: reloading integration", DOMAIN)
+        _LOGGER.info("Service %s.reload called: reloading integration", DOMAIN)
         current_entries = hass.config_entries.async_entries(DOMAIN)
 
         reload_tasks = [

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -222,10 +222,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up hass_agent integration."""
     hass.http.register_view(MediaPlayerThumbnailView(hass))
 
-    async def reload_config(_: ServiceCall) -> None:
+#    async def reload_config(_: ServiceCall) -> None:
         """Reload configuration."""
-        await process_config(await async_integration_yaml_config(hass, DOMAIN))
+#        await process_config(await async_integration_yaml_config(hass, DOMAIN))
 
-    async_register_admin_service(hass, DOMAIN, SERVICE_RELOAD, reload_config)
+    async_register_admin_service(hass, DOMAIN, SERVICE_RELOAD)
 
     return True

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -11,8 +11,6 @@ import requests
 from typing import Any, cast
 from .views import MediaPlayerThumbnailView
 
-#import voluptuous as vol
-
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.components import mqtt
 from homeassistant.components.mqtt.models import ReceiveMessage
@@ -25,8 +23,6 @@ from homeassistant.const import (
     CONF_ID,
     CONF_NAME, 
     CONF_URL, 
-#    DATA_MQTT,
-#    DATA_MQTT_AVAILABLE,
     Platform, 
     SERVICE_RELOAD,
 )

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -25,8 +25,8 @@ from homeassistant.const import (
     CONF_ID,
     CONF_NAME, 
     CONF_URL, 
-    DATA_MQTT,
-    DATA_MQTT_AVAILABLE,
+#    DATA_MQTT,
+#    DATA_MQTT_AVAILABLE,
     Platform, 
     SERVICE_RELOAD,
 )

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -39,7 +39,7 @@ from .const import DOMAIN
 DOMAIN = "hass_agent"
 FOLDER = "hass_agent"
 
-PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.]
+PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
 
 _logger = logging.getLogger(__name__)
 

--- a/custom_components/hass_agent/manifest.json
+++ b/custom_components/hass_agent/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "hass_agent",
   "name": "HASS.Agent",
-  "version": "2022.11.9",
+  "version": "2024.5.0",
   "config_flow": true,
   "documentation": "https://github.com/LAB02-Research/HASS.Agent-Integration",
   "issue_tracker": "https://github.com/LAB02-Research/HASS.Agent-Integration/issues",


### PR DESCRIPTION
Fixes/closes [HASS-Agent fails to load when HA is restarted but succeeds when manually reloaded #43](https://github.com/LAB02-Research/HASS.Agent-Integration/issues/43)
